### PR TITLE
fix: allow passing full alertmanager URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ go build ./...
 Start kthxbye and pass the address of Alertmanager you want it to manage.
 
 ```shell
-$ kthxbye -alertmanager.addr alertmanager.example.com:9093
+$ kthxbye -alertmanager.uri http://alertmanager.example.com:9093
 ```
 
 By default kthxbye will only extend silences with comment starting with `ACK!`,

--- a/cmd/kthxbye/alert.go
+++ b/cmd/kthxbye/alert.go
@@ -22,7 +22,7 @@ func queryAlerts(ctx context.Context, cfg *ackConfig) ([]*models.GettableAlert, 
 		WithInhibited(&withInhibited).
 		WithSilenced(&withSilenced)
 
-	amclient := newAMClient(cfg.alertmanagerHostPort, cfg.alertmanagerAPIPath)
+	amclient := newAMClient(cfg.alertmanagerURI)
 
 	getOk, err := amclient.Alert.GetAlerts(alertParams)
 

--- a/cmd/kthxbye/main.go
+++ b/cmd/kthxbye/main.go
@@ -39,21 +39,19 @@ var (
 )
 
 type ackConfig struct {
-	alertmanagerHostPort string
-	alertmanagerAPIPath  string
-	loopInterval         time.Duration
-	extendIfExpiringIn   time.Duration
-	extendBy             time.Duration
-	extendWithPrefix     string
-	maxDuration          time.Duration
+	alertmanagerURI    string
+	loopInterval       time.Duration
+	extendIfExpiringIn time.Duration
+	extendBy           time.Duration
+	extendWithPrefix   string
+	maxDuration        time.Duration
 }
 
 func main() {
 	addr := flag.String("listen", ":8080", "The address to listen on for HTTP requests.")
 
 	cfg := ackConfig{}
-	flag.StringVar(&cfg.alertmanagerHostPort, "alertmanager.addr", "localhost:9093", "The address of the alertmanager")
-	flag.StringVar(&cfg.alertmanagerAPIPath, "alertmanager.api", "/api/v2", "Base path for the alertmanager API")
+	flag.StringVar(&cfg.alertmanagerURI, "alertmanager.uri", "http://localhost:9093", "Alertmanager URI to use")
 	flag.DurationVar(&cfg.loopInterval, "interval", time.Duration(time.Second*45), "Silence check interval")
 	flag.DurationVar(&cfg.extendIfExpiringIn, "extend-if-expiring-in", time.Duration(time.Minute*5), "Extend silences that are about to expire in the next DURATION seconds")
 	flag.DurationVar(&cfg.extendBy, "extend-by", time.Duration(time.Minute*15), "Extend silences by adding DURATION seconds")

--- a/cmd/kthxbye/silence.go
+++ b/cmd/kthxbye/silence.go
@@ -14,7 +14,7 @@ func querySilences(ctx context.Context, cfg *ackConfig) ([]*models.GettableSilen
 
 	silenceParams := silence.NewGetSilencesParams().WithContext(ctx)
 
-	amclient := newAMClient(cfg.alertmanagerHostPort, cfg.alertmanagerAPIPath)
+	amclient := newAMClient(cfg.alertmanagerURI)
 
 	getOk, err := amclient.Silence.GetSilences(silenceParams)
 	if err != nil {
@@ -37,7 +37,7 @@ func updateSilence(ctx context.Context, cfg *ackConfig, sil *models.GettableSile
 		Silence: sil.Silence,
 	}
 
-	amclient := newAMClient(cfg.alertmanagerHostPort, cfg.alertmanagerAPIPath)
+	amclient := newAMClient(cfg.alertmanagerURI)
 
 	silenceParams := silence.NewPostSilencesParams().WithContext(ctx).WithSilence(ps)
 	postOk, err := amclient.Silence.PostSilences(silenceParams)


### PR DESCRIPTION
This is so we can support basic auth.

Fixes #45